### PR TITLE
Adding a missed word in vmalloc()

### DIFF
--- a/docs/lkd/ch12.md
+++ b/docs/lkd/ch12.md
@@ -389,7 +389,7 @@ As in user-space, be careful to balance your allocations with your deallocations
 
 ### `vmalloc()`
 
-The `vmalloc()` function works in a similar fashion to `kmalloc()`, except `vmalloc()` allocates memory that is only virtually contiguous and not necessarily physically contiguous. This is similar to user-space `malloc()`, the returned pages by which are contiguous within the virtual address space, but necessarily contiguous in physical RAM.
+The `vmalloc()` function works in a similar fashion to `kmalloc()`, except `vmalloc()` allocates memory that is only virtually contiguous and not necessarily physically contiguous. This is similar to user-space `malloc()`, the returned pages by which are contiguous within the virtual address space, but not necessarily contiguous in physical RAM.
 
 The `vmalloc()` function ensures that the pages are physically contiguous by by allocating potentially noncontiguous chunks of physical memory and "fixing up" the page tables to map the memory into a contiguous chunk of the logical address space.
 


### PR DESCRIPTION
while describing `malloc()`, 'not' was missing in 
"but not necessarily contiguous in physical RAM."