### PR TITLE
fix wrong title of chapter 6

### DIFF
--- a/docs/dda/ch6.md
+++ b/docs/dda/ch6.md
@@ -1,4 +1,4 @@
-### **Chatper 6. Replication**
+### **Chatper 6. Partitioning**
 
 In [Chapter 5](ch5.md) we discussed replication, that is, having multiple copies of the same data on different nodes. For very large datasets, or very high query throughput, that is not sufficient: we need to break the data up into *partitions*, also known as *sharding*.
 


### PR DESCRIPTION
The title of chapter 5 was carried over to chapter 6 as a typo

<img width="420" alt="image" src="https://github.com/shichao-an/notes/assets/63918341/6123fc6b-7e96-439a-82f2-00d504145cd3">
